### PR TITLE
Catch when the directory path has spaces

### DIFF
--- a/src/Scripts/Lint JavaScript.sh
+++ b/src/Scripts/Lint JavaScript.sh
@@ -13,10 +13,10 @@ FORMAT_COMPACT="(?P<file>.+?): line (?P<line>\d+), (col (?P<col>\d+),)? (?P<type
 DIR=$(dirname "${BB_DOC_PATH}")
 
 # move to current directory to provide context for npm
-cd $DIR
+cd "$DIR"
 
 # Run eslint in npm project
-RESPONSE=$($(npm bin)/eslint $BB_DOC_PATH --format compact)
+RESPONSE=$($(npm bin)/eslint "$BB_DOC_PATH" --format compact)
 
 CHARCOUNT=$(echo "${RESPONSE}" | wc -m)
 


### PR DESCRIPTION
Script would throw an error if the file was in a directory that had spaces in the folder name. Using quotes around the name addresses this.