### PR TITLE
chore: npm bin and shellcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ The package file will be copied to the Packages directory in BBEdit’s Applicat
 
 ### Bring your own ESLint
 
-As noted in the requirements, this package does not install ESLint itself. The contained script presumes `eslint` is [installed](http://eslint.org/docs/user-guide/command-line-interface) and [configured](http://eslint.org/docs/user-guide/configuring) with a configuration file (such as .eslintrc.js or a `eslintConfig` field in a package.json).
+As noted in the requirements, this package does not install ESLint itself. The contained script presumes `eslint` is [installed](http://eslint.org/docs/user-guide/command-line-interface) and [configured](http://eslint.org/docs/user-guide/configuring) with a configuration file (such as eslint.config.js or a `eslintConfig` field in a package.json).
+
+The script calls eslint with the `--format compact` option. The compact formatter is no longer part of core ESLint. Install it manually with `npm install -D eslint-formatter-compact`.
 
 ## Usage
 

--- a/src/Info.plist
+++ b/src/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.0.1</string>
 </dict>
 </plist>


### PR DESCRIPTION
* Updated the main script to use `which eslint` instead of deprecated `npm bin` 
* Added check & warning if eslint isn't installed
* Resolved shellcheck warnings about script (BBEdit menu item, #! > Check Syntax ⌘ K)
* Updated README for contemporary ESLint config file name
* Updated README with note about the need to install `eslint-formatter-compact`
* Bumped version from 3.0.0 -> 3.0.1

Thanks for the great utility. I hope this helps others who may use it.

Tested locally using macOS Sequoia 15.4.1, BBEdit 15.1.4, and eslint v9.25.1
